### PR TITLE
Added editMessageReplyMarkup which allows to modify inlineKeyboards, or delete them.

### DIFF
--- a/src/AsyncTelegram.cpp
+++ b/src/AsyncTelegram.cpp
@@ -337,6 +337,7 @@ MessageType AsyncTelegram::getNewMessage(TBMessage &message )
         if(root["result"][0]["callback_query"]["id"]){
             // this is a callback query
             message.callbackQueryID   = root["result"][0]["callback_query"]["id"];
+            message.chatId            = root["result"][0]["callback_query"]["message"]["chat"]["id"];
             message.sender.id         = root["result"][0]["callback_query"]["from"]["id"];
             message.sender.username   = root["result"][0]["callback_query"]["from"]["username"];
             message.sender.firstName  = root["result"][0]["callback_query"]["from"]["first_name"];
@@ -353,6 +354,7 @@ MessageType AsyncTelegram::getNewMessage(TBMessage &message )
         else if(root["result"][0]["message"]["message_id"]){
             // this is a message
             message.messageID        = root["result"][0]["message"]["message_id"];
+            message.chatId           = root["result"][0]["message"]["chat"]["id"];
             message.sender.id        = root["result"][0]["message"]["from"]["id"];
             message.sender.username  = root["result"][0]["message"]["from"]["username"];
             message.sender.firstName = root["result"][0]["message"]["from"]["first_name"];
@@ -651,7 +653,7 @@ void AsyncTelegram::editMessageReplyMarkup(TBMessage &msg, String keyboard) // k
 
     DynamicJsonDocument root(BUFFER_SMALL);   
 
-    root["chat_id"] = msg.sender.id;
+    root["chat_id"] = msg.chatId;
     root["message_id"] = msg.messageID;
     
     if (msg.isMarkdownEnabled)

--- a/src/AsyncTelegram.cpp
+++ b/src/AsyncTelegram.cpp
@@ -642,6 +642,44 @@ void AsyncTelegram::removeReplyKeyboard(const TBMessage &msg, const char* messag
     sendMessage(msg, message, command);
 }
 
+void AsyncTelegram::editMessageReplyMarkup(TBMessage &msg, String keyboard) // keyboard value defaulted to ""
+{
+    if (sizeof(msg) == 0)
+    return;
+    String buffer((char *)0);
+    buffer.reserve(256);
+
+    DynamicJsonDocument root(BUFFER_SMALL);   
+
+    root["chat_id"] = msg.sender.id;
+    root["message_id"] = msg.messageID;
+    
+    if (msg.isMarkdownEnabled)
+        root["parse_mode"] = "Markdown";
+    
+    if (keyboard.length() != 0) {
+        DynamicJsonDocument doc(512);
+        deserializeJson(doc, keyboard);
+        JsonObject myKeyb = doc.as<JsonObject>();
+        root["reply_markup"] = myKeyb;
+    }
+    
+    serializeJson(root, buffer);
+    sendCommand("editMessageReplyMarkup", buffer.c_str());
+    
+    #if DEBUG_MODE > 0
+    serialLog("SEND message:\n");
+    serializeJsonPretty(root, Serial);
+    serialLog("\n");
+    #endif
+}
+
+void AsyncTelegram::editMessageReplyMarkup(TBMessage &msg, InlineKeyboard &keyboard)
+{
+    m_inlineKeyboard = keyboard;
+    return editMessageReplyMarkup(msg, keyboard.getJSON());
+}
+
 
 bool AsyncTelegram::serverReply(const char* const& replyMsg) {  
     DynamicJsonDocument root(BUFFER_SMALL);

--- a/src/AsyncTelegram.h
+++ b/src/AsyncTelegram.h
@@ -152,6 +152,10 @@ public:
     // return:
     //   true if no error occurred
     void removeReplyKeyboard(const TBMessage &msg, const char* message, bool selective = false);
+    
+    // Use this method to edit only the reply markup of messages.
+    void editMessageReplyMarkup(TBMessage &msg, String keyboard = "");
+    void editMessageReplyMarkup(TBMessage &msg, InlineKeyboard &keyboard);
 
     // set the new Telegram API server fingerprint overwriting the default one.
     // It can be obtained by this service: https://www.grc.com/fingerprints.htm

--- a/src/DataStructures.h
+++ b/src/DataStructures.h
@@ -53,6 +53,7 @@ struct TBDocument {
 
 struct TBMessage {
 	int32_t          messageID;
+	int64_t          chatId;
 	TBUser           sender;
 	TBGroup          group;
 	int32_t          date;


### PR DESCRIPTION
This functions allows you to redefined the text shown by an already sent inlineKeyboard.
I also added chatId to TBmessage struct because every message has one, and is not always the same as the sender.id.

For example, if an inlineKeyboard is sent to a group, anyone in the group can click on it, and consequently the sender.id will change accordingly, but the chatId will remain the same.