### PR TITLE
Correct bug ESP32 loop error, when not response server and correct example ESP32-CAM with ffat format.

### DIFF
--- a/src/AsyncTelegram.cpp
+++ b/src/AsyncTelegram.cpp
@@ -291,6 +291,12 @@ bool AsyncTelegram::getUpdates(){
         return true;
     }
     #else
+        // No response from server for a long time, reset connection ESP32
+        if(millis() - httpData.timestamp > 10*m_minUpdateTime){ 
+          Serial.println("Reset connection ESP32");
+          httpData.timestamp = millis(); 
+          if (!reset()) checkConnection();
+        }
         return ! httpData.waitingReply;
     #endif
     return false;
@@ -438,8 +444,8 @@ bool AsyncTelegram::getFile(TBDocument &doc)
 }
 
 bool AsyncTelegram::begin(){
-	telegramClient.setInsecure();
 #if defined(ESP8266)
+	telegramClient.setInsecure();
     telegramClient.setBufferSizes(1024,1024);
     telegramClient.setNoDelay(true);
 #elif defined(ESP32)


### PR DESCRIPTION
Corrects infinite loop error, when not receiving response from the server, due to packet loss, bad wifi or very slow lines.
It also corrects the example of ESP32-CAM with ffat format, in this example it would be good as an improvement, to make the camera active only at the time of taking the photo, it avoids a consumption of about 40mA and improves the performance of the wifi.
You could use "esp_camera_deinit ()" to disable the camera.